### PR TITLE
curly apostrophes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
-title: Jonathan Vollebregt's stuff
+title: Jonathan Vollebregt’s stuff
 email: jnvsor@gmail.com
 url: "http://jnvsor.github.io"
 description:
-  I'm a programmer. I program stuff.
+  I’m a programmer. I program stuff.
 github_username: jnvsor
 author: &author "Jonathan Vollebregt"
 


### PR DESCRIPTION
inside of articles the markdown engine converts straight apostrophes to curly ones. in other places that must be done by hand.